### PR TITLE
Fix #1 and merge code from Mariln

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1113,6 +1113,14 @@ void process_commands()
           SERIAL_PROTOCOLPGM(" /");
           SERIAL_PROTOCOL_F(degTargetBed(),1);
         #endif //TEMP_BED_PIN
+        for (int8_t cur_extruder = 0; cur_extruder < EXTRUDERS; ++cur_extruder) {
+        SERIAL_PROTOCOLPGM(" T");
+        SERIAL_PROTOCOL(cur_extruder);
+        SERIAL_PROTOCOLPGM(":");
+        SERIAL_PROTOCOL_F(degHotend(cur_extruder),1);
+        SERIAL_PROTOCOLPGM(" /");
+        SERIAL_PROTOCOL_F(degTargetHotend(cur_extruder),1);
+        }
       #else
         SERIAL_ERROR_START;
         SERIAL_ERRORLNPGM(MSG_ERR_NO_THERMISTORS);


### PR DESCRIPTION
Code from:
https://github.com/MarlinFirmware/Marlin/blob/Development/Marlin/Marlin_main.cpp#L2451
Without it M105 command will not return the temperature of a second extruder.

Many thanks to @foosel for spotting this out, I would have never figured this out.
I have no idea how you actually tested the printer without this loop.

Tested
